### PR TITLE
fixes in target preprocessing for query generation and in best params search inside TreeParamOptimizer

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.10"
 
       - name: pre-commit
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.1
 
   codespell:
     runs-on: ubuntu-latest

--- a/autowoe/lib/autowoe.py
+++ b/autowoe/lib/autowoe.py
@@ -722,8 +722,8 @@ class AutoWoE:
             self._target_scaler = StandardScaler()
             target_values = self._target_scaler.fit_transform(self.target.values.reshape(-1, 1))
             self.target.loc[:] = target_values.ravel()
-            self._target_std = self._target_scaler.mean_[0]
-            self._target_mean = self._target_scaler.scale_[0]
+            self._target_std = self._target_scaler.scale_[0]
+            self._target_mean = self._target_scaler.mean_[0]
 
     def _train_encoding(self, train: pd.DataFrame, spec_values: Dict, folds_codding: bool) -> pd.DataFrame:  # TODO: ref
         """Encode a train dataset based on WoE estimates."""

--- a/autowoe/lib/optimizer/optimizer.py
+++ b/autowoe/lib/optimizer/optimizer.py
@@ -112,11 +112,11 @@ class TreeParamOptimizer:
         stats = np.array(stats)
         median_, std_ = np.median(stats, axis=(1, 2)), np.std(stats, axis=(1, 2))
 
-        id_max = zip(*(median_, -std_))  # номер комбинации с наилучшим качеством
-        id_max = max(enumerate(id_max), key=lambda x: x[1])[0]
+        scores = zip(*(median_ if self._task == TaskType.BIN else -median_, -std_))
+        id_best = max(enumerate(scores), key=lambda x: x[1])[0]
 
         stat_score = zip(*(median_, std_))
-        self._params_stats = OrderedDict((key, value) for (key, value) in zip(self.__params_gen, stat_score)), id_max
+        self._params_stats = OrderedDict((key, value) for (key, value) in zip(self.__params_gen, stat_score)), id_best
 
     def __call__(self, n: int) -> Dict[str, Union[int, str, None]]:
         """Execute optimization.


### PR DESCRIPTION
- Fix in target preprocessing for the regression task. This fix corrects an error in constructing the SQL query for generating the score map.
- Fix in selecting the best splits for a feature for the regression task. When using default parameters, this bug does not affect the selection of the best split. However, the quality of bin splits degrade when the `max_bin_count` parameter is set.