### PR TITLE
Fix FutureWarning "Value 'Small' has dtype incompatible with float32"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.10"
 
       - name: pre-commit
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.1
 
   codespell:
     runs-on: ubuntu-latest

--- a/autowoe/lib/pipelines/pipeline_feature_special_values.py
+++ b/autowoe/lib/pipelines/pipeline_feature_special_values.py
@@ -159,6 +159,9 @@ class FeatureSpecialValues:
                     enc_type = "__Small__"
                     # d[enc_type] = None
 
+                if train_.loc[:, col].dtypes != object: # trouble when we have numerical col
+                    train_[col] = train_[col].astype(object)
+
                 train_.loc[train_[col].isin(small_cat), col] = enc_type
                 cat_encoding[col] = big_cat.difference(small_cat), small_cat, enc_type
                 #  Небольшие категории, которые будем кодировать отдельно

--- a/autowoe/lib/pipelines/pipeline_feature_special_values.py
+++ b/autowoe/lib/pipelines/pipeline_feature_special_values.py
@@ -159,7 +159,7 @@ class FeatureSpecialValues:
                     enc_type = "__Small__"
                     # d[enc_type] = None
 
-                if train_.loc[:, col].dtypes != object: # trouble when we have numerical col
+                if train_.loc[:, col].dtypes is not object:  # trouble when we have numerical col
                     train_[col] = train_[col].astype(object)
 
                 train_.loc[train_[col].isin(small_cat), col] = enc_type

--- a/autowoe/lib/woe/woe.py
+++ b/autowoe/lib/woe/woe.py
@@ -56,7 +56,7 @@ class WoE:
     def __woe(self, df: pd.DataFrame) -> Tuple[Dict, DataFrame, Tuple[float, ...]]:
         """Calculate WoE coefficient for each category values."""
         df.columns = [0, "target"]
-        stat = df.groupby(0)["target"].agg([np.mean, np.count_nonzero, np.size])
+        stat = df.groupby(0)["target"].agg(["mean", np.count_nonzero, np.size])
 
         if self.target_type == TaskType.BIN:
             stat["bad"] = stat["size"] - stat["count_nonzero"]
@@ -88,6 +88,13 @@ class WoE:
 
         x_.loc[x_.isin(spec_values_)] = -np.inf
         df_cod = self.__codding(x_)
+
+        if len(x.loc[x.isin(spec_values_)]) == 0 or len(spec_values_) == 0:
+            return df_cod
+
+        if df_cod.dtypes != object:
+            df_cod = df_cod.astype(object)
+
         df_cod.loc[x.isin(spec_values_)] = x.loc[x.isin(spec_values_)]
 
         return df_cod
@@ -240,5 +247,5 @@ class WoE:
         for value in cv_index_split.values():
             train_index, test_index = value
             self.fit(x.iloc[train_index], y.iloc[train_index], spec_values)
-            x_.iloc[test_index] = self.transform(x.iloc[test_index], spec_values)
+            x_.iloc[test_index] = self.transform(x.iloc[test_index], spec_values).astype(x.dtype)
         return x_.astype(float)

--- a/autowoe/lib/woe/woe.py
+++ b/autowoe/lib/woe/woe.py
@@ -92,7 +92,7 @@ class WoE:
         if len(x.loc[x.isin(spec_values_)]) == 0 or len(spec_values_) == 0:
             return df_cod
 
-        if df_cod.dtypes != object:
+        if df_cod.dtypes is not object:
             df_cod = df_cod.astype(object)
 
         df_cod.loc[x.isin(spec_values_)] = x.loc[x.isin(spec_values_)]


### PR DESCRIPTION
Fix """FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '__Small__' has dtype incompatible with float32, please explicitly cast to a compatible dtype first."""  raising from [TestWhiteBoxPreset](https://github.com/sb-ai-lab/LightAutoML/blob/master/tests/unit/test_automl/test_presets/test_whiteboxpreset.py)